### PR TITLE
encode校验码也需要转义

### DIFF
--- a/src/main/java/cn/hylexus/jt808/service/codec/MsgEncoder.java
+++ b/src/main/java/cn/hylexus/jt808/service/codec/MsgEncoder.java
@@ -92,6 +92,6 @@ public class MsgEncoder {
 				new byte[] { TPMSConsts.pkg_delimiter }// 0x7e
 		));
 		// 转义
-		return jt808ProtocolUtils.doEscape4Send(noEscapedBytes, 1, noEscapedBytes.length - 2);
+		return jt808ProtocolUtils.doEscape4Send(noEscapedBytes, 1, noEscapedBytes.length - 1);
 	}
 }


### PR DESCRIPTION
encode转义的时候，校验码也需要转义。
return jt808ProtocolUtils.doEscape4Send(noEscapedBytes, 1, noEscapedBytes.length - 2);  
修改为：
return jt808ProtocolUtils.doEscape4Send(noEscapedBytes, 1, noEscapedBytes.length - 1);